### PR TITLE
Implement Ranking Table Based on Win Percentage

### DIFF
--- a/src/app.jac
+++ b/src/app.jac
@@ -9,6 +9,7 @@ import:jac from components.llm_eval, evaluator;
 import:jac from components.about, about;
 import:jac from components.theme, footer;
 import:jac from components.emb_sim_scorer, ui_components;
+import:jac from components.model_ranking, model_win_percentage_table;
 
 can main {
     if "admin_privileges" not in st.session_state {st.session_state.admin_privileges = False;} 
@@ -23,9 +24,10 @@ can main {
             with dashboard_tab {dashboard();}
             with generator_tab {generator();}
             with evaluation_tab {
-                (gpt_evaluator, sim_scorer_tab) = st.tabs(["GPT Evaluator","Similarity Scorer"]);
+                (gpt_evaluator, sim_scorer_tab,model_ranking) = st.tabs(["GPT Evaluator","Similarity Scorer","Model Ranking"]);
                 with gpt_evaluator {evaluator();}
                 with sim_scorer_tab {ui_components();}
+                with model_ranking {model_win_percentage_table();}
                 
             }
             with setup_tab {setup();}

--- a/src/components/model_ranking.jac
+++ b/src/components/model_ranking.jac
@@ -1,0 +1,48 @@
+import:py pandas as pd;
+import:py streamlit as st;
+import:py from py_utils, format_responses_by_prompt, get_unique_prompt_ids;
+
+can model_win_percentage_table {
+    if st.session_state.get("current_hv_config", None) {
+        criteria = ["overall"];
+        model_performance = {model: {"wins": 0, "total": 0} for model in st.session_state.active_list_of_models};
+        formatted_data = format_responses_by_prompt(st.session_state.workers_data_dir, st.session_state.distribution_file, st.session_state.response_file);
+        prompt_info = get_unique_prompt_ids(st.session_state.prompt_data_dir,st.session_state.prompt_info_file);
+        prompt_ids = list(prompt_info.keys());
+        prompt_ids.insert(0, "all_combined");
+        user_selected_prompt = st.selectbox("Select Prompt:", prompt_ids, key="select_box_win");
+
+        if user_selected_prompt != "all_combined"{user_selected_prompt=prompt_info[user_selected_prompt];}
+        for outputs in formatted_data{
+            if user_selected_prompt == "all_combined" or outputs["prompt_id"] == user_selected_prompt{
+                for response in outputs["responses"] {
+                    model1 = response["model_a"];
+                    model2 = response["model_b"];
+                    result = response.get("overall");
+                    if result == "Response A"{
+                        model_performance[model1]["wins"] += 1;
+                    }
+                    elif result == "Response B"{
+                        model_performance[model2]["wins"] += 1;
+                    }
+                    model_performance[model1]["total"] += 1;
+                    model_performance[model2]["total"] += 1;
+                }
+            }
+        }
+
+        data = [];
+        for (model, counts) in model_performance.items() {
+            win_percentage = (counts["wins"] / counts["total"]) if counts["total"] else 0;
+            data.append({"Model": model, "Win Percentage": win_percentage });
+        }
+        df = pd.DataFrame(data);
+        df = df.sort_values(by='Win Percentage', ascending=False);
+        df['Rank'] = range(1, len(df) + 1);
+        df = df[['Rank', 'Model', 'Win Percentage']];
+        (col1, col2, col3) = st.columns([1,2,1]);
+        with col2{st.dataframe(df.set_index('Rank'), width=430, height=435);}
+    } else {
+        st.error("Human Evaluation config was not found. Initialize a Human Evaluation first.");
+    }    
+}


### PR DESCRIPTION
# **Name of PR**
Implement Ranking Table Based on Win Percentage
## Reference Issue

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->
#12 
## **Description**

<!--  📛📛
Please include a summary of the change and/or which issue is fixed.
List any dependencies required for this change, if there are any.
📛📛 -->

* This pull request introduces a new ranking table feature that displays models sorted by their win percentage. The table comprises three columns: Rank, Model Name, and Win Percentage. An additional filter functionality has been implemented to allow users to filter the rankings based on prompt ID. This enhancement is expected to significantly improve the user's ability to analyze model performance directly within the platform.
---

### **Additional context**

<!-- Add any other context or additional information about the pull request.-->

*

<!-- 📛📛📛📛
If it fixes any current issue please let us know this way:
Uncomment the comment above "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛📛 -->
