### PR TITLE
Fix worker count exhaustion bug

### DIFF
--- a/src/components/human_eval.impl.jac
+++ b/src/components/human_eval.impl.jac
@@ -32,7 +32,7 @@ import:py string;
 :can:worker_id {
     with st.container(border=True) {
         st.session_state.worker_id = st.text_input("Worker ID");
-        if st.session_state.worker_id {st.rerun();}
+        if st.session_state.worker_id {st.session_state.increase_worker_count = True; st.rerun();}
         st.caption("Please enter your worker ID to start the survey. Make sure to use the correct worker ID, otherwise you will not be paid.");
     }
 }

--- a/src/components/human_eval.jac
+++ b/src/components/human_eval.jac
@@ -11,25 +11,31 @@ can worker_id;
 can human_eval {
     if "hv_config" not in st.session_state {<>init();}
     if st.session_state.get("hv_config", None) {
+        if "worker_count" in st.session_state {
+            if st.session_state.worker_count is None {
+                if os.path.exists(os.path.join(".human_eval_config", "worker_count.txt")) {
+                    with open(os.path.join(".human_eval_config", "worker_count.txt"), "r") as f {st.session_state.worker_count= int(f.read());}
+                } else {
+                    with open(os.path.join(".human_eval_config", "worker_count.txt"), "w") as f {f.write("-1");}
+                    st.session_state.worker_count = -1;
+                }
+            }
+            if "increase_worker_count" in st.session_state and st.session_state.increase_worker_count {
+                st.session_state.worker_count = st.session_state.worker_count + 1;
+                with open(os.path.join(".human_eval_config", "worker_count.txt"), "w") as f {f.write(str(st.session_state.worker_count));}
+                st.session_state.increase_worker_count = False;
+            }
+            if st.session_state.worker_count >= st.session_state.hv_config["config"]["n_workers"] {
+            st.info("Thank you for your interest in participating! However, we have currently reached our capacity for workers. Please check back later for availability. We appreciate your understanding.");
+                return;
+            }
+        }
         if not st.session_state.worker_id or not st.session_state.is_human {
             (captcha_col, worker_id_col) = st.columns(2);
             with captcha_col {captcha_gen();}
             with worker_id_col {worker_id();}
+            
         } else {
-            if st.session_state.worker_count is None {
-                if os.path.exists(os.path.join(".human_eval_config", "worker_count.txt")) {
-                    with open(os.path.join(".human_eval_config", "worker_count.txt"), "r") as f {current_count = int(f.read());}
-                } else {
-                    with open(os.path.join(".human_eval_config", "worker_count.txt"), "w") as f {f.write("-1");}
-                    current_count = -1;
-                }
-                if current_count >= st.session_state.hv_config["config"]["n_workers"] {
-                    st.error("Something seems to be Wrong. Dev team is notified. Please Try Again Later. Thank You!");
-                    return;
-                }
-                st.session_state.worker_count = current_count + 1;
-                with open(os.path.join(".human_eval_config", "worker_count.txt"), "w") as f {f.write(str(st.session_state.worker_count));}
-            }
             if not st.session_state.question_set_id {
                 with open(os.path.join(".human_eval_config", "distribution.json"), "r") as f {all_questions = json.load(f);}
                 st.session_state.question_set_id = list(all_questions.keys())[st.session_state.worker_count];


### PR DESCRIPTION
# **Fix Worker Count exhaustion bug**
Fix worker count exhaustion bug
## Reference Issue

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->
#9 
## **Description**

<!--  📛📛
Please include a summary of the change and/or which issue is fixed.
List any dependencies required for this change, if there are any.
📛📛 -->

* This PR resolves an issue within the human evaluation system where workers were allowed to proceed through the login process, including captcha verification and worker ID submission, even after reaching the maximum allowed worker count. The implemented fix moves the worker count check to the beginning of the login process. 

### Changes
* The worker count is now checked immediately upon login attempt before presenting the captcha and worker ID input fields.
---

### **Additional context**

<!-- Add any other context or additional information about the pull request.-->

*

<!-- 📛📛📛📛
If it fixes any current issue please let us know this way:
Uncomment the comment above "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛📛 -->
