### PR TITLE
Ability to Add Prompt Descriptions Straight from the Tool

### DIFF
--- a/src/components/dashboard.impl.jac
+++ b/src/components/dashboard.impl.jac
@@ -15,7 +15,9 @@ import:py shutil;
 :can:<>init {
     if os.path.exists(os.path.join(".human_eval_config", "config.json")) {
         st.session_state.current_hv_config = json.load(open(os.path.join(".human_eval_config", "config.json")));
-        with open(os.path.join(".human_eval_config", "worker_count.txt"), "r") as f {st.session_state.current_worker_count = int(f.read());}
+        if os.path.exists(os.path.join(".human_eval_config", "worker_count.txt")) {
+            with open(os.path.join(".human_eval_config", "worker_count.txt"), "r") as f {st.session_state.current_worker_count = int(f.read());}
+        } else {st.session_state.current_worker_count = 0;}
         st.session_state.workers_data_dir = os.path.abspath("results");
         st.session_state.distribution_file = os.path.abspath(os.path.join(".human_eval_config", "distribution.json"));
         st.session_state.response_file = os.path.abspath(os.path.join(".human_eval_config", "responses.json"));

--- a/src/components/dashboard.jac
+++ b/src/components/dashboard.jac
@@ -33,5 +33,8 @@ can dashboard {
     } else {
         <>init();
     }
-    if st.button("Refresh") {st.rerun();}
+    if st.button("Refresh") {
+        <>init();
+        st.rerun();
+    }
 }

--- a/src/components/dashboard.jac
+++ b/src/components/dashboard.jac
@@ -14,7 +14,7 @@ can plotly_histogram;
 glob SELECTED_PROMPT_KEY = 'selected_prompt';
 
 can dashboard {
-    if st.session_state.get("current_hv_config", None) {
+    if st.session_state.get("current_hv_config", None){
         status_indicator();
         # chart_type = st.selectbox("Select a chart type:", ("Area Chart", "Bar Chart", "Line Chart", "Altair Chart", "Plotly Figure", "Heat Map","Stacked Bar Chart","Histogram"));
         chart_type = st.selectbox("Select a chart type:", ("Plotly Figure", "Heat Map","Stacked Bar Chart","Histogram"));

--- a/src/components/llm_as_evaluator.impl.jac
+++ b/src/components/llm_as_evaluator.impl.jac
@@ -43,7 +43,7 @@ import:jac from utils, llms, check_engine_status, load_engine, run_inference;
                 evals = [];
                 for question in question_set {
                     prompt_id = question[0];
-                    prompt_disc = [x["prompt_disc_simple"] for x in st.session_state.prompt_info if x["prompt_id"] == prompt_id][0];
+                    prompt_disc = [x["prompt_simple_disc"] for x in st.session_state.prompt_info if x["prompt_id"] == prompt_id][0];
                     (model_a, model_a_respones_id) = list(question[1].items())[0];
                     (model_b, model_b_respones_id) = list(question[1].items())[1];
                     model_a_respones = st.session_state.responses[model_a_respones_id];

--- a/src/components/setup.impl.jac
+++ b/src/components/setup.impl.jac
@@ -161,20 +161,20 @@ import:py random;
     }
     with open(os.path.join(".human_eval_config", "distribution.json"), "w") as f {json.dump(distribution, f, indent=2);}
 }
-:can:create_neccessary_file (data_sources: list) {
+:can:create_neccessary_file (data_sources: list, _prompt_infos: dict) {
     with st.spinner("Creating Necessary Files...") {
         uid_responses = {};
         models_responses_all = {};
         prompt_infos = [];
         for data_source in data_sources {
-            prompt_id = str(uuid.uuid4());
             prompt_info = {};
             models_responses = {};
             with open(os.path.join("data", data_source)) as f {
                 data = json.load(f);
                 prompt_info["prompt"] = data["prompt"];
-                prompt_info["prompt_disc"] = data["prompt_disc"];
-                prompt_info["prompt_id"] = prompt_id;
+                prompt_info["prompt_disc"] = _prompt_infos[data_source]["prompt_disc"];
+                prompt_info["prompt_id"] = _prompt_infos[data_source]["usecase_id"];
+                prompt_info["prompt_simple_disc"] = _prompt_infos[data_source]["prompt_simple_disc"];
                 for (model_name, responses) in data["outputs"].items() {
                     model_responses = [];
                     for response in responses {
@@ -186,7 +186,7 @@ import:py random;
                 }
             }
             prompt_infos.append(prompt_info);
-            models_responses_all[prompt_id] = models_responses;
+            models_responses_all[_prompt_infos[data_source]["usecase_id"]] = models_responses;
         }
         json.dump(uid_responses, open(os.path.join(".human_eval_config", "responses.json"), "w"), indent=2);
         json.dump(models_responses_all, open(os.path.join(".human_eval_config", "models_responses.json"), "w"), indent=2);
@@ -196,6 +196,7 @@ import:py random;
     return models_responses_all;
 }
 :can:get_prompt_info(data_sources: list) {
+    st.subheader("Prompt Information");
     prompt_infos = {data_source: {} for data_source in data_sources};
     with st.container(border=True) {
         for data_source in data_sources {
@@ -209,7 +210,7 @@ import:py random;
                 }
                 with tab_preview {
                     st.caption("Preview of the prompt description. Note: Following is a representation of what evaluators will see.");
-                    st.markdown(prompt_infos[data_source]["prompt_disc"]);
+                    st.markdown(prompt_infos[data_source]["prompt_disc"], unsafe_allow_html=True);
                 }
             }
         }

--- a/src/components/setup.impl.jac
+++ b/src/components/setup.impl.jac
@@ -28,7 +28,6 @@ import:py random;
         st.session_state.config = config;
     }
 }
-
 :can:hv_evaluation_method_selector {
     eval_methods = {
         "A/B Testing": {"desc":"A/B Testing is a method where the user is shown two options and they have to choose the better one. This is repeated for a number of times and the option with the most votes wins.", "image": "https://i.imgur.com/5ZQJX6i.png"},
@@ -47,13 +46,11 @@ import:py random;
     }
     return hv_method;
 }
-
 :can:sanity_check (n_models: int, n_usecases: int, n_workers: int, n_questions_per_worker: int) {
     n_model_pairs = n_models * (n_models - 1) / 2;
     min_n_responses_needed_per_model = int(math.ceil(math.sqrt(n_workers * n_questions_per_worker / n_usecases / float(n_model_pairs))));
     return (min_n_responses_needed_per_model, n_model_pairs);
 }
-
 :can:hv_configurator {
     st.subheader("Human Evaluation Configuration");
     (hv_config_1_col, hv_config_2_col, hv_config_3_col) = st.columns(3);
@@ -92,7 +89,6 @@ import:py random;
     }
     return (n_options, n_workers, ability_to_tie, data_sources, n_questions_per_worker, evenly_distributed, show_captcha);
 }
-
 :can:add_data_sources {
     with st.form("upload_datasources", clear_on_submit=True) {
         uploaded_json_files = st.file_uploader("Upload data sources", accept_multiple_files=True, <>type="json");
@@ -107,7 +103,6 @@ import:py random;
         }
     }
 }
-
 :can:get_question_pairs (models_responses_all: dict) {
     n_usecases = len(models_responses_all);
     models = list(list(models_responses_all.values())[0].keys());
@@ -135,7 +130,6 @@ import:py random;
     with open(os.path.join(".human_eval_config", "unique_question_pairs.json"), "w") as f {json.dump(question_pairs, f, indent=2);}
     return question_pairs;
 }
-
 :can:get_distribution (question_pairs:list, n_workers: int, n_questions_per_worker: int) {
     need_to_be_evenly_distributed = st.session_state.config["config"]["evenly_distributed"];
     if not need_to_be_evenly_distributed {
@@ -167,7 +161,6 @@ import:py random;
     }
     with open(os.path.join(".human_eval_config", "distribution.json"), "w") as f {json.dump(distribution, f, indent=2);}
 }
-
 :can:create_neccessary_file (data_sources: list) {
     with st.spinner("Creating Necessary Files...") {
         uid_responses = {};
@@ -201,4 +194,25 @@ import:py random;
     }
 
     return models_responses_all;
+}
+:can:get_prompt_info(data_sources: list) {
+    prompt_infos = {data_source: {} for data_source in data_sources};
+    with st.container(border=True) {
+        for data_source in data_sources {
+            with st.expander(f"Usecase {data_source}"){
+                with open(os.path.join("data", data_source)) as f {data = json.load(f);}
+                (tab_input, tab_preview) = st.tabs(["Prompt Information", "Preview"]);
+                with tab_input {
+                    prompt_infos[data_source]["usecase_id"] = st.text_input("Usecase Identifier", key=f"{data_source}_usecase_id", value=str(uuid.uuid4()), help="Unique ID for the usecase.");
+                    prompt_infos[data_source]["prompt_disc"] = st.text_area("Prompt Description", key=f"{data_source}_prompt_disc", value=data.get("prompt_disc", ""), help="Display description of the prompt. Use markdown/html for Nice looks.");
+                    prompt_infos[data_source]["prompt_simple_disc"] = st.text_area("Simple Description", key=f"{data_source}_prompt_simple_disc", value="", help="Simple text description of the usecase. Note: This will be used in the Auto Evaluation.");
+                }
+                with tab_preview {
+                    st.caption("Preview of the prompt description. Note: Following is a representation of what evaluators will see.");
+                    st.markdown(prompt_infos[data_source]["prompt_disc"]);
+                }
+            }
+        }
+    }
+    return prompt_infos;
 }

--- a/src/components/setup.jac
+++ b/src/components/setup.jac
@@ -11,10 +11,10 @@ can get_distribution (question_pairs:list, n_workers: int, n_questions_per_worke
 can <>init;
 can hv_evaluation_method_selector;
 can hv_configurator;
-can get_prompt_info(data_sources: list) -> list[dict];
+can get_prompt_info(data_sources: list) -> dict;
 can add_data_sources;
 
-can create_neccessary_file (data_sources: list);
+can create_neccessary_file (data_sources: list, _prompt_infos: dict);
 
 can setup {
     <>init();
@@ -28,7 +28,7 @@ can setup {
     }
 
     if data_sources {
-        # prompt_info = get_prompt_info(data_sources);
+        prompt_infos = get_prompt_info(data_sources);
         if st.button("Save"){
             os.makedirs(".human_eval_config", exist_ok=True);
             config = {
@@ -49,7 +49,7 @@ can setup {
             
             json.dump(config, open(os.path.join(".human_eval_config", "config.json"), "w"));
 
-            models_responses_all = create_neccessary_file(data_sources);
+            models_responses_all = create_neccessary_file(data_sources, prompt_infos);
             question_pairs = get_question_pairs(models_responses_all);
             get_distribution(question_pairs, n_workers, n_questions_per_worker);
             st.toast("Created necessary files!");

--- a/src/components/setup.jac
+++ b/src/components/setup.jac
@@ -11,7 +11,9 @@ can get_distribution (question_pairs:list, n_workers: int, n_questions_per_worke
 can <>init;
 can hv_evaluation_method_selector;
 can hv_configurator;
+can get_prompt_info(data_sources: list) -> list[dict];
 can add_data_sources;
+
 can create_neccessary_file (data_sources: list);
 
 can setup {
@@ -26,6 +28,7 @@ can setup {
     }
 
     if data_sources {
+        # prompt_info = get_prompt_info(data_sources);
         if st.button("Save"){
             os.makedirs(".human_eval_config", exist_ok=True);
             config = {

--- a/src/components/utils.jac
+++ b/src/components/utils.jac
@@ -95,7 +95,7 @@ can login {
     with login_col {
         with st.form(key='my_form') {
             username = st.text_input('Username');
-            password = st.text_input('Password');
+            password = st.text_input('Password', <>type='password');
             if st.form_submit_button('Login') {
                 try {
                     if username == os.environ.get("SLAM_ADMIN_USERNAME") and password == os.environ.get("SLAM_ADMIN_PASSWORD"){


### PR DESCRIPTION
# **Ability to Add Prompt Descriptions Straight from the Tool**

## Reference Issue
https://app.clickup.com/t/86enpq19y
<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

<!--  📛📛
Please include a summary of the change and/or which issue is fixed.
List any dependencies required for this change, if there are any.
📛📛 -->

* Currently You have manually add the prompt description (The Display Description) for the data files. Now can do it straight from the tool

---

### **Additional context**

<!-- Add any other context or additional information about the pull request.-->

* Nothing

<!-- 📛📛📛📛
If it fixes any current issue please let us know this way:
Uncomment the comment above "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛📛 -->
